### PR TITLE
Fixed mobile layout

### DIFF
--- a/Resources/CSS/index.css
+++ b/Resources/CSS/index.css
@@ -305,7 +305,7 @@ p{
     font-size: 2.5vw;
     }
 
-    .projects-container{
+    .default-container{
     flex-wrap: wrap;
     }
     .display-container{


### PR DESCRIPTION
This commit is addressing an issue caused by me renaming the 'projects-container' class to 'default-container'. I did this as it made sense to reuse this container outside of the projects section. I forgot to change it in the media query for mobile devices. This issue has now been resolved.